### PR TITLE
fix: Move away from premium endpoint

### DIFF
--- a/sopel_modules/stocks/providers/alphavantage.py
+++ b/sopel_modules/stocks/providers/alphavantage.py
@@ -3,7 +3,7 @@ import requests
 
 
 def alphavantage(bot, symbol):
-    r = requests.get('https://www.alphavantage.co/query?function=TIME_SERIES_DAILY&symbol={symbol}&apikey={api_key}'.format(symbol=symbol, api_key=bot.config.stocks.api_key))
+    r = requests.get('https://www.alphavantage.co/query?function=TIME_SERIES_DAILY_ADJUSTED&symbol={symbol}&apikey={api_key}'.format(symbol=symbol, api_key=bot.config.stocks.api_key))
 
     if not r.json():
         raise Exception('An error occurred.')


### PR DESCRIPTION
The TIME_SERIES_DAILY endpoint is premium now, which essentially took my bot offline, but it looks like we can just move to TIME_SERIES_DAILY_ADJUSTED.

Briefly tested this and my bot works as expected.